### PR TITLE
loosen oauth2 dependency, release version 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+## 1.2.0 (2019-06-25)
+* Allow dependencies to be more flexible and use old authentication
+
+## 2.0.2 (2016-04-04)
+* Change repo link
+
+## 2.0.1 (2016-04-04)
+* Fix typo
+
+## 2.0.0 (2016-04-04)
+* Use doorkeeper as `oauth2` authentication provider via `auth` app
+
+## 1.1.0 (2012-07-30)
+* Authenticate through `kaeuferportal` app
+
+## 0.9.0 (2011-12-05)
+* Initial version

--- a/lib/omniauth-kaeuferportal/version.rb
+++ b/lib/omniauth-kaeuferportal/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Kaeuferportal
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/omniauth-kaeuferportal.gemspec
+++ b/omniauth-kaeuferportal.gemspec
@@ -2,8 +2,8 @@
 require File.expand_path('../lib/omniauth-kaeuferportal/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'omniauth', '~> 1.1.0'
-  gem.add_dependency 'oauth2', '=0.7.1'
+  gem.add_dependency 'omniauth', '~> 1.0'
+  gem.add_dependency 'oauth2', '~> 1.1.0'
 
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
This pull request aims to release a new (lower) version of this gem which will be compatible with the `auth` upgrade.

### Manual Testing

* Use a local version of this gem
* update `config/omniauth_providers.yml` in `auth` (ask me for credentials)
* set `fake_auth=false` in your KP app of choice (I used `beratung`)
* try to login and logout using KP to authenticate